### PR TITLE
use different ports for config_db server lists for different configs

### DIFF
--- a/manifests/network/contrail/analytics.pp
+++ b/manifests/network/contrail/analytics.pp
@@ -248,6 +248,7 @@ class tripleo::network::contrail::analytics(
   $config_api_server_list_8082 = join([join($config_server_list, ':8082 '),':8082'],'')
   $collector_server_list_8086 = join([join($analytics_server_list, ':8086 '),':8086'],'')
   $config_db_server_list_9042 = join([join($config_server_list, ':9042 '),':9042'],'')
+  $config_db_server_list_9160 = join([join($config_server_list, ':9160 '),':9160'],'')
   $redis_server_list_6379 = join([join($analytics_server_list, ':6379 '),':6379'],'')
   $kafka_broker_list_9092 = join([join($kafka_broker_list, ':9092 '),':9092'],'')
   $rabbit_server_list_5672 = join([join($rabbit_server, ':5672,'),':5672'],'')
@@ -520,12 +521,13 @@ class tripleo::network::contrail::analytics(
         keystone_config          => {
           'KEYSTONE'     => $keystone_config,
         },
-        rabbitmq_server_list     => $rabbit_server_list_no_port,
-        rabbitmq_port            => '5672',
-        rabbitmq_vhost           => $rabbit_vhost,
-        rabbitmq_user            => $rabbit_user,
-        rabbitmq_password        => $rabbit_password,
-        config_db_server_list    => $config_db_server_list_9042,
+        rabbitmq_server_list         => $rabbit_server_list_no_port,
+        rabbitmq_port                => '5672',
+        rabbitmq_vhost               => $rabbit_vhost,
+        rabbitmq_user                => $rabbit_user,
+        rabbitmq_password            => $rabbit_password,
+        config_db_cql_server_list    => $config_db_server_list_9042,
+        config_db_server_list        => $config_db_server_list_9160,
       }
     }
   }


### PR DESCRIPTION
collector config use another port for config db than alarm-gen,
 snmp-collector and topology