### PR TITLE
Setup webui at step 5

### DIFF
--- a/manifests/network/contrail/webui.pp
+++ b/manifests/network/contrail/webui.pp
@@ -18,6 +18,9 @@
 # Configure Contrail Webui services
 #
 # == Parameters:
+# [*step*]
+#  The current step of the deployment
+#  Defaults to hiera('step')
 #
 # [*admin_password*]
 #  (optional) admin password
@@ -100,6 +103,7 @@
 #  Defaults to '127.0.0.1'
 #
 class tripleo::network::contrail::webui(
+  $step                      = Integer(hiera('step')),
   $admin_password            = hiera('contrail::admin_password'),
   $admin_tenant_name         = hiera('contrail::admin_tenant_name'),
   $admin_token               = hiera('contrail::admin_token'),
@@ -118,22 +122,24 @@ class tripleo::network::contrail::webui(
   $redis_ip                  = hiera('contrail::webui::redis_ip'),
 )
 {
-  class {'::contrail::webui':
-    admin_user                => $admin_user,
-    admin_password            => $admin_password,
-    admin_token               => $admin_token,
-    admin_tenant_name         => $admin_tenant_name,
-    auth_port                 => $auth_port_public,
-    auth_protocol             => $auth_protocol,
-    auth_version              => $auth_version,
-    cassandra_ip              => $cassandra_server_list,
-    cert_file                 => $cert_file,
-    contrail_config_vip       => $contrail_config_vip,
-    contrail_analytics_vip    => $contrail_analytics_vip,
-    contrail_webui_http_port  => $contrail_webui_http_port,
-    contrail_webui_https_port => $contrail_webui_https_port,
-    neutron_vip               => $neutron_vip,
-    openstack_vip             => $auth_host,
-    redis_ip                  => $redis_ip,
+  if $step >= 5 {
+    class {'::contrail::webui':
+      admin_user                => $admin_user,
+      admin_password            => $admin_password,
+      admin_token               => $admin_token,
+      admin_tenant_name         => $admin_tenant_name,
+      auth_port                 => $auth_port_public,
+      auth_protocol             => $auth_protocol,
+      auth_version              => $auth_version,
+      cassandra_ip              => $cassandra_server_list,
+      cert_file                 => $cert_file,
+      contrail_config_vip       => $contrail_config_vip,
+      contrail_analytics_vip    => $contrail_analytics_vip,
+      contrail_webui_http_port  => $contrail_webui_http_port,
+      contrail_webui_https_port => $contrail_webui_https_port,
+      neutron_vip               => $neutron_vip,
+      openstack_vip             => $auth_host,
+      redis_ip                  => $redis_ip,
+    }
   }
 }


### PR DESCRIPTION
This is to avoid installation of java
by dependencies before config DB is installed.
Config DB now has fixed java version because of #1743900.